### PR TITLE
Update sepolicy_vndr to current version and remove duplicate fstype

### DIFF
--- a/basic/non_plat/charger_vendor.te
+++ b/basic/non_plat/charger_vendor.te
@@ -1,0 +1,4 @@
+allow charger_vendor gpu_device:dir search;
+allow charger_vendor dri_device:chr_file rw_file_perms;
+allow charger_vendor graphics_device:dir search;
+allow charger_vendor graphics_device:chr_file rw_file_perms;

--- a/basic/non_plat/file.te
+++ b/basic/non_plat/file.te
@@ -381,9 +381,6 @@ type debugfs_ion, fs_type, debugfs_type;
 ##########################
 # Other Filesystem types
 #
-# for labeling /mnt/cd-rom as iso9660
-type iso9660, fs_type;
-
 # rawfs for /protect_f on NAND projects
 type rawfs, fs_type, mlstrustedobject;
 

--- a/basic/non_plat/genfs_contexts
+++ b/basic/non_plat/genfs_contexts
@@ -639,9 +639,6 @@ genfscon debugfs /mmprofile          u:object_r:debugfs_fb:s0
 ##########################
 # other files
 #
-genfscon iso9660 / u:object_r:iso9660:s0
-genfscon rawfs /   u:object_r:rawfs:s0
-
 # move from plat_private to non_plat
 genfscon sysfs /firmware/devicetree/base/chosen/atag,boot    u:object_r:sysfs_boot_info:s0
 


### PR DESCRIPTION
Remove duplicate fstype with los sepolicy for /mnt/cd-rom as iso9660 from [file.te](https://github.com/marcinmajsc/device_mediatek_sepolicy_vndr/commit/4fc8afe74127e1ba39bd85561453dced4e90edd1)
Remove unused fstype from [genfs_contexts](https://github.com/marcinmajsc/device_mediatek_sepolicy_vndr/commit/9f78a7e4addb53b69a6bd80cac1465288b2771a2)

basic: non_plat: Allow charger_vendor to access drm/fb device nodes
Change-Id: Id7f386b46015ef4ad2b7c6af54ba0c149c7080fb
Signed-off-by: bengris32 <bengris32@protonmail.ch>